### PR TITLE
[update] security header 대문자로 변경

### DIFF
--- a/back-end/src/main/java/com/dreamteam/hola/config/SecurityConfiguration.java
+++ b/back-end/src/main/java/com/dreamteam/hola/config/SecurityConfiguration.java
@@ -81,7 +81,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.addAllowedOriginPattern(CorsConfiguration.ALL);
         configuration.setAllowedMethods(List.of(CorsConfiguration.ALL));
-        configuration.setAllowedHeaders(Arrays.asList("authorization", "content-type", "x-auth-token", "X-Requested-With","accept", "Origin", "Access-Control-Request-Method", "Access-Control-Request-Headers"));
+        configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type", "X-Auth-Token", "X-Requested-With","Accept", "Origin", "Access-Control-Request-Method", "Access-Control-Request-Headers"));
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;

--- a/back-end/src/main/java/com/dreamteam/hola/util/cors/CorsFilter.java
+++ b/back-end/src/main/java/com/dreamteam/hola/util/cors/CorsFilter.java
@@ -24,7 +24,7 @@ public class CorsFilter implements Filter {
         response.setHeader("Access-Control-Allow-Methods","*");
         response.setHeader("Access-Control-Max-Age", "3600");
         response.setHeader("Access-Control-Allow-Headers",
-                "Origin, X-Requested-With, Content-Type, Accept, Key, Authorization, x-auth-token, Access-Control-Request-Method, Access-Control-Request-Headers");
+                "Origin, X-Requested-With, Content-Type, Accept, Key, Authorization, X-Auth-Token, Access-Control-Request-Method, Access-Control-Request-Headers");
 
         if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
             log.info("여기 들어와????");


### PR DESCRIPTION
security cors 설정을 추가해도 계속 프론트 쪽에서 cors error가 발생해서 header 설정을 대문자로 변경해봄

```
@Bean
    CorsConfigurationSource corsConfigurationSource() {
        CorsConfiguration configuration = new CorsConfiguration();
        configuration.addAllowedOriginPattern(CorsConfiguration.ALL);
        configuration.setAllowedMethods(List.of(CorsConfiguration.ALL));
        configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type", "X-Auth-Token", "X-Requested-With","Accept", "Origin", "Access-Control-Request-Method", "Access-Control-Request-Headers"));
        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
        source.registerCorsConfiguration("/**", configuration);
        return source;
    }
```